### PR TITLE
change cordova to ionic cordova in travis build scripts

### DIFF
--- a/travis/build-android.sh
+++ b/travis/build-android.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Build Ionic App for Android
-cordova platform add android --nofetch
+ionic cordova platform add android --nofetch
 
 if [[ "$TRAVIS_BRANCH" == "develop" ]]
 then

--- a/travis/build-ios.sh
+++ b/travis/build-ios.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Build Ionic App for iOS
-cordova platform add ios --nofetch
+ionic cordova platform add ios --nofetch
 
 if [[ "$TRAVIS_BRANCH" == "develop" ]]
 then


### PR DESCRIPTION
Fixes travis runtime error:

# Build Ionic App for Android
cordova platform add android --nofetch
Error: Current working directory is not a Cordova-based project.
